### PR TITLE
feat: Apply initial Jules-inspired styling to homepage

### DIFF
--- a/src/components/Greeting.jsx
+++ b/src/components/Greeting.jsx
@@ -8,8 +8,11 @@ export default function Greeting({messages}) {
 
   return (
     <div>
-      <h3>{greeting} ¡Gracias por tu visita!</h3>
-      <button onClick={() => setGreeting(randomMessage())}>
+      <h3 className="text-julesAmber-50 text-2xl font-bold mb-4">{greeting} ¡Gracias por tu visita!</h3>
+      <button
+        onClick={() => setGreeting(randomMessage())}
+        className="inline-flex items-center justify-center px-6 py-3 text-base font-bold rounded-md text-julesPurple-50 bg-julesPurple-500 hover:bg-julesPurple-400 focus:outline-none focus:ring-2 focus:ring-julesPurple-300 focus:ring-offset-2 focus:ring-offset-julesEditorBg transition-colors"
+      >
         Nuevo saludo
       </button>
     </div>

--- a/src/components/Hamburger.astro
+++ b/src/components/Hamburger.astro
@@ -9,7 +9,7 @@
   aria-expanded="false"
   aria-controls="nav-links-menu"
 >
-  <span class="line block w-10 h-1 mb-2 bg-orange-400"></span>
-  <span class="line block w-10 h-1 mb-2 bg-orange-400"></span>
-  <span class="line block w-10 h-1 bg-orange-400"></span>
+  <span class="line block w-10 h-1 mb-2 bg-julesPurple-50"></span>
+  <span class="line block w-10 h-1 mb-2 bg-julesPurple-50"></span>
+  <span class="line block w-10 h-1 bg-julesPurple-50"></span>
 </button>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -4,12 +4,12 @@ import Navigation from "./Navigation.astro";
 import ThemeIcon from "./ThemeIcon.astro";
 ---
 
-<header class="py-4 relative">
-  <nav class="flex justify-between items-center">
+<header class="flex flex-row items-center justify-between w-full p-4 absolute top-0 left-0 z-50 bg-julesDarkBg">
+  <nav class="flex justify-between items-center w-full">
     <div class="flex items-center">
       <a
         href="/"
-        class="text-xl font-bold text-slate-800 dark:text-slate-200 hover:text-purple-700 dark:hover:text-purple-400 mr-4"
+        class="text-xl font-bold text-julesPurple-50 hover:text-julesPurple-300 mr-4"
         >Glitch and Glory</a
       >
       <Hamburger />

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -3,27 +3,27 @@
 ---
 
 <div
-  class="nav-links hidden md:flex md:items-center md:w-auto md:static md:bg-transparent absolute top-full left-0 w-full z-10 flex flex-col bg-orange-400 dark:bg-orange-600 md:relative md:top-auto md:left-auto md:w-auto md:z-auto md:flex-row"
+  class="nav-links hidden md:flex md:items-center md:w-auto md:static md:bg-transparent absolute top-full left-0 w-full z-10 flex flex-col bg-julesDarkBg md:relative md:top-auto md:left-auto md:w-auto md:z-auto md:flex-row"
   id="nav-links-menu"
 >
   <a
     href="/"
-    class="block text-center py-2 px-4 text-lg font-bold uppercase hover:bg-orange-500 focus:bg-orange-500 md:inline-block md:py-4 md:px-5 dark:text-white"
+    class="block text-center py-2 px-4 text-lg font-bold uppercase text-julesPurple-50 hover:bg-julesPurple-500 focus:bg-julesPurple-500 md:hover:bg-transparent md:hover:text-julesPurple-300 md:inline-block md:py-4 md:px-5"
     >Inicio</a
   >
   <a
     href="/about/"
-    class="block text-center py-2 px-4 text-lg font-bold uppercase hover:bg-orange-500 focus:bg-orange-500 md:inline-block md:py-4 md:px-5 dark:text-white"
+    class="block text-center py-2 px-4 text-lg font-bold uppercase text-julesPurple-50 hover:bg-julesPurple-500 focus:bg-julesPurple-500 md:hover:bg-transparent md:hover:text-julesPurple-300 md:inline-block md:py-4 md:px-5"
     >Sobre mi</a
   >
   <a
     href="/blog/"
-    class="block text-center py-2 px-4 text-lg font-bold uppercase hover:bg-orange-500 focus:bg-orange-500 md:inline-block md:py-4 md:px-5 dark:text-white"
+    class="block text-center py-2 px-4 text-lg font-bold uppercase text-julesPurple-50 hover:bg-julesPurple-500 focus:bg-julesPurple-500 md:hover:bg-transparent md:hover:text-julesPurple-300 md:inline-block md:py-4 md:px-5"
     >Blog</a
   >
   <a
     href="/tags/"
-    class="block text-center py-2 px-4 text-lg font-bold uppercase hover:bg-orange-500 focus:bg-orange-500 md:inline-block md:py-4 md:px-5 dark:text-white"
+    class="block text-center py-2 px-4 text-lg font-bold uppercase text-julesPurple-50 hover:bg-julesPurple-500 focus:bg-julesPurple-500 md:hover:bg-transparent md:hover:text-julesPurple-300 md:inline-block md:py-4 md:px-5"
     >Etiquetas</a
   >
 </div>

--- a/src/components/ThemeIcon.astro
+++ b/src/components/ThemeIcon.astro
@@ -2,7 +2,7 @@
 
 ---
 
-<button id="themeToggle" type="button">
+<button id="themeToggle" type="button" class="text-julesPurple-50 hover:text-julesPurple-300">
   <svg width="30px" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
     <path
       class="sun"
@@ -23,7 +23,7 @@
     background: none;
   }
   .sun {
-    fill: black;
+    fill: currentColor;
   }
   .moon {
     fill: transparent;
@@ -33,7 +33,7 @@
     fill: transparent;
   }
   :global(.dark) .moon {
-    fill: white;
+    fill: currentColor;
   }
 </style>
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,7 +5,7 @@ import "../styles/global.css";
 const { pageTitle } = Astro.props;
 ---
 
-<html lang="es" class="bg-slate-100 dark:bg-slate-900 dark:text-white">
+<html lang="es" class="dark text-julesPurple-50">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -13,7 +13,7 @@ const { pageTitle } = Astro.props;
     <meta name="generator" content={Astro.generator} />
     <title>{pageTitle}</title>
   </head>
-  <body class="font-sans max-w-3xl mx-auto p-4 leading-relaxed">
+  <body class="font-sans leading-relaxed bg-julesEditorBg text-julesPurple-50 min-h-screen flex flex-col">
     <Header />
     <h1 class="text-4xl my-4">{pageTitle}</h1>
     <slot />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,6 +5,8 @@ const pageTitle = "Página de inicio";
 ---
 
 <BaseLayout pageTitle={pageTitle}>
-  <h2>Mi impresionante subtítulo del blog</h2>
-  <Greeting client:load messages={["Hej", "Hallo", "Hola", "Habari"]} />
+  <main class="pt-20 pb-10 w-full max-w-screen-lg mx-auto px-4">
+    <h2 class="text-julesPurple-50">Mi impresionante subtítulo del blog</h2>
+    <Greeting client:load messages={["Hej", "Hallo", "Hola", "Habari"]} />
+  </main>
 </BaseLayout>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -3,7 +3,21 @@ export default {
   content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
   darkMode: 'class', // To integrate with Astro's existing dark mode toggle
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        julesDarkBg: '#1D0245',
+        julesEditorBg: '#2A0B5C',
+        julesPurple: {
+          '50': '#FAF5FF',
+          '300': '#D8B4FE',
+          '400': '#C084FC',
+          '500': '#A855F7',
+        },
+        julesAmber: {
+          '50': '#FFFBEB',
+        },
+      },
+    },
   },
   plugins: [
     require('@tailwindcss/typography'),


### PR DESCRIPTION
This commit introduces a new visual style to the homepage, inspired by the "Jules" interface aesthetic.

Key changes include:

1.  **Tailwind Configuration (`tailwind.config.mjs`):**
    *   Added a custom color palette (julesPurple, julesAmber, julesDarkBg, julesEditorBg)
    *   Ensured `darkMode: 'class'` is active.

2.  **Base Layout (`src/layouts/BaseLayout.astro`):**
    *   Enforced dark mode by default on the `<html>` tag.
    *   Removed max-width constraints from the `<body>` for a full-width design.
    *   Applied a dark background (`bg-julesEditorBg`) and default light text color (`text-julesPurple-50`) to the body.

3.  **Header (`src/components/Header.astro` and sub-components):**
    *   Restyled the header to be full-width, absolutely positioned at the top, with a `bg-julesDarkBg` background.
    *   Updated text and icon colors within the header (`Navigation.astro`, `Hamburger.astro`, `ThemeIcon.astro`) to contrast with the new dark background and use the Jules color palette.

4.  **Homepage Content (`src/pages/index.astro`):**
    *   Added top padding to the main content area to account for the new absolute header.
    *   Constrained content width to `max-w-screen-lg` and centered it.
    *   Styled the `<h2>` element with appropriate text color.

5.  **Greeting Component (`src/components/Greeting.jsx`):**
    *   Styled the `<h3>` with `text-julesAmber-50`.
    *   Applied "Jules-like" button styling (colors, padding, font, focus states) to the component's button.

These changes establish the foundational dark theme and key styling patterns for the homepage. Further refinements and styling of other site sections will follow.